### PR TITLE
Fixed ambiguous comparison

### DIFF
--- a/src/handlerstorage.cpp
+++ b/src/handlerstorage.cpp
@@ -161,7 +161,7 @@ QStringList HandlerStorage::stripCall(const QString &call)
     }
 
     // Space outside a quote means the end of a word
-    if (*iter == " " && !in_quote) {
+    if (*iter == ' ' && !in_quote) {
       // Don't process stuff like %1, %2, etc.
       if (!word.contains(invalid_arguments)) {
         results << word;


### PR DESCRIPTION
Not sure whether this is because of 5.15.2 or VS 16.9 P3, but the comparison is ambiguous because `*iter` is a `QChar`, not a string.