### PR TITLE
Add EnderalSE support.

### DIFF
--- a/src/handlerstorage.cpp
+++ b/src/handlerstorage.cpp
@@ -137,6 +137,7 @@ std::vector<std::tuple<QString, QString, QString>> HandlerStorage::knownGames() 
     std::make_tuple<QString, QString, QString>("Skyrim", "skyrim", "skyrim"),
     std::make_tuple<QString, QString, QString>("SkyrimSE", "skyrimse", "skyrimspecialedition"),
     std::make_tuple<QString, QString, QString>("Enderal", "enderal", "enderal"),
+    std::make_tuple<QString, QString, QString>("EnderalSE", "enderalse", "enderalspecialedition"),
     std::make_tuple<QString, QString, QString>("Other", "other", "other")
   };
 }


### PR DESCRIPTION
Add the short name <> nexus name conversion required for Enderal SE.

We talked about modifying the way this works globally and I agreed, but the changes won't be included before (at least) 2.5.0 and EnderalSE is out on Steam in 2 weeks so this is small temporary changes for 2.4.1.