### PR TITLE
Add modl:// support

### DIFF
--- a/src/handlerstorage.cpp
+++ b/src/handlerstorage.cpp
@@ -26,22 +26,24 @@ void HandlerStorage::clear()
 
 void HandlerStorage::registerProxy(const QString &proxyPath)
 {
-    {
-        QSettings settings("HKEY_CURRENT_USER\\Software\\Classes\\nxm\\", QSettings::NativeFormat);
-        QString myExe = QString("\"%1\" ").arg(QDir::toNativeSeparators(proxyPath)).append("\"%1\"");
-        settings.setValue("Default", "URL:NXM Protocol");
-        settings.setValue("URL Protocol", "");
-        settings.setValue("shell/open/command/Default", myExe);
-        settings.sync();
-    }
-    {
-        QSettings settings("HKEY_CURRENT_USER\\Software\\Classes\\modl\\", QSettings::NativeFormat);
-        QString myExe = QString("\"%1\" ").arg(QDir::toNativeSeparators(proxyPath)).append("\"%1\"");
-        settings.setValue("Default", "URL:MODL Protocol");
-        settings.setValue("URL Protocol", "");
-        settings.setValue("shell/open/command/Default", myExe);
-        settings.sync();
-    }
+  QSettings settings("HKEY_CURRENT_USER\\Software\\Classes\\nxm\\", QSettings::NativeFormat);
+  QString myExe = QString("\"%1\" ").arg(QDir::toNativeSeparators(proxyPath)).append("\"%1\"");
+  settings.setValue("Default", "URL:NXM Protocol");
+  settings.setValue("URL Protocol", "");
+  settings.setValue("shell/open/command/Default", myExe);
+  settings.sync();
+
+  registerModlProxy(proxyPath);
+}
+
+void HandlerStorage::registerModlProxy(const QString& proxyPath)
+{
+  QSettings settings("HKEY_CURRENT_USER\\Software\\Classes\\modl\\", QSettings::NativeFormat);
+  QString myExe = QString("\"%1\" ").arg(QDir::toNativeSeparators(proxyPath)).append("\"%1\"");
+  settings.setValue("Default", "URL:MODL Protocol");
+  settings.setValue("URL Protocol", "");
+  settings.setValue("shell/open/command/Default", myExe);
+  settings.sync();
 }
 
 void HandlerStorage::registerHandler(const QString &executable, const QString &arguments, bool prepend)

--- a/src/handlerstorage.cpp
+++ b/src/handlerstorage.cpp
@@ -26,12 +26,22 @@ void HandlerStorage::clear()
 
 void HandlerStorage::registerProxy(const QString &proxyPath)
 {
-  QSettings settings("HKEY_CURRENT_USER\\Software\\Classes\\nxm\\", QSettings::NativeFormat);
-  QString myExe = QString("\"%1\" ").arg(QDir::toNativeSeparators(proxyPath)).append("\"%1\"");
-  settings.setValue("Default", "URL:NXM Protocol");
-  settings.setValue("URL Protocol", "");
-  settings.setValue("shell/open/command/Default", myExe);
-  settings.sync();
+    {
+        QSettings settings("HKEY_CURRENT_USER\\Software\\Classes\\nxm\\", QSettings::NativeFormat);
+        QString myExe = QString("\"%1\" ").arg(QDir::toNativeSeparators(proxyPath)).append("\"%1\"");
+        settings.setValue("Default", "URL:NXM Protocol");
+        settings.setValue("URL Protocol", "");
+        settings.setValue("shell/open/command/Default", myExe);
+        settings.sync();
+    }
+    {
+        QSettings settings("HKEY_CURRENT_USER\\Software\\Classes\\modl\\", QSettings::NativeFormat);
+        QString myExe = QString("\"%1\" ").arg(QDir::toNativeSeparators(proxyPath)).append("\"%1\"");
+        settings.setValue("Default", "URL:MODL Protocol");
+        settings.setValue("URL Protocol", "");
+        settings.setValue("shell/open/command/Default", myExe);
+        settings.sync();
+    }
 }
 
 void HandlerStorage::registerHandler(const QString &executable, const QString &arguments, bool prepend)

--- a/src/handlerstorage.h
+++ b/src/handlerstorage.h
@@ -25,6 +25,7 @@ public:
   void clear();
   /// register the primary proxy handler
   void registerProxy(const QString &proxyPath);
+  void registerModlProxy(const QString& proxyPath);
   /// register handler (for all games)
   void registerHandler(const QString &executable, const QString &arguments, bool prepend);
   /// register handler for specified games

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
       if ((args.at(1) == "reg") || (args.at(1) == "forcereg")) {
         if (args.count() == 4) {
           storage->registerHandler(args.at(2).split(",", Qt::SkipEmptyParts), QDir::toNativeSeparators(args.at(3)), "", true, forceReg);
-          storage->registerProxy(QCoreApplication::applicationFilePath());
+          storage->registerModlProxy(QCoreApplication::applicationFilePath());
           if (forceReg) {
             applyChromeFix();
           }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,8 +277,6 @@ int main(int argc, char *argv[])
           QUrlQuery query(url.query());
           QStringList handlerVals = storage->getHandler(url.host());
           QString executable = handlerVals.front();
-          handlerVals.pop_front();
-          QString arguments = handlerVals.join(" ");
           if (!executable.isEmpty()) {
               handleLink(executable, "download", QUrl::fromPercentEncoding(query.queryItemValue("url").toUtf8()));
               return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -280,7 +280,7 @@ int main(int argc, char *argv[])
           handlerVals.pop_front();
           QString arguments = handlerVals.join(" ");
           if (!executable.isEmpty()) {
-              handleLink(executable, "download", query.queryItemValue("url"));
+              handleLink(executable, "download", QUrl::fromPercentEncoding(query.queryItemValue("url").toUtf8()));
               return 0;
           }
           else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,8 @@
 #include <QRegularExpression>
 #include <QDateTime>
 #include <QStandardPaths>
+#include <QUrl>
+#include <QUrlQuery>
 #include "logger.h"
 
 
@@ -183,7 +185,7 @@ static void applyChromeFix()
     // toObject returns empty object if the key doesn't exist. Therefore if excluded_schemes exists, protocol_handler existed as well
     if (handlers.contains("excluded_schemes")) {
       QJsonObject schemes = handlers["excluded_schemes"].toObject();
-      if (schemes["nxm"].toBool(true)) {
+      if (schemes["nxm"].toBool(true) || schemes["modl"].toBool(true)) {
         if (QMessageBox::question(nullptr, "Apply Chrome fix",
                                   "Chrome may not support nexus links even though the association is set up correctly. "
                                   "Do you want to apply a fix for that (You have to close chrome before pressing yes or "
@@ -192,6 +194,7 @@ static void applyChromeFix()
           return;
         }
         schemes["nxm"] = false;
+        schemes["modl"] = false;
         handlers["excluded_schemes"] = schemes;
         docMap["protocol_handler"] = handlers;
         QByteArray result = QJsonDocument(docMap).toJson();
@@ -243,6 +246,7 @@ int main(int argc, char *argv[])
       if ((args.at(1) == "reg") || (args.at(1) == "forcereg")) {
         if (args.count() == 4) {
           storage->registerHandler(args.at(2).split(",", Qt::SkipEmptyParts), QDir::toNativeSeparators(args.at(3)), "", true, forceReg);
+          storage->registerProxy(QCoreApplication::applicationFilePath());
           if (forceReg) {
             applyChromeFix();
           }
@@ -268,6 +272,24 @@ int main(int argc, char *argv[])
                                             "the links that MO doesn't.").arg(url.game()));
           return 1;
         }
+      } else if (args.at(1).startsWith("modl://")) {
+          QUrl url(args.at(1));
+          QUrlQuery query(url.query());
+          QStringList handlerVals = storage->getHandler(url.host());
+          QString executable = handlerVals.front();
+          handlerVals.pop_front();
+          QString arguments = handlerVals.join(" ");
+          if (!executable.isEmpty()) {
+              handleLink(executable, "download", query.queryItemValue("url"));
+              return 0;
+          }
+          else {
+              QMessageBox::warning(nullptr, QObject::tr("No handler found"),
+                  QObject::tr("No application registered to handle this game (%1).\n"
+                      "If you expected Mod Organizer to handle the link, "
+                      "you have to go to Settings->Nexus and click the \"Associate with ... links\"-button.").arg(url.host()));
+              return 1;
+          }
       } else {
         QMessageBox::warning(nullptr, QObject::tr("Invalid Arguments"), QObject::tr("Invalid number of parameters"));
         return 1;


### PR DESCRIPTION
Following the [commit](https://github.com/ModOrganizer2/modorganizer/commit/59b5b1cfca1614df681055d98d602692f482f0e2), adding support for https:// download links, adds support for a new link schema to nxmhandler.exe:
`modl://MO_GAME_ID/?url=URL`

URLs are expected to be encoded using RFC 3986 (for example, with [rawurlencode](https://www.php.net/manual/en/function.rawurlencode.php) in PHP).

Available game IDs can be found in [HandlerStorage::knownGames()](https://github.com/ModOrganizer2/modorganizer-nxmhandler/blob/master/src/handlerstorage.cpp#L128).

Test:
`start "" "modl://falloutnv/?url=https://eddoursul.win/Cyberware%20TTW%20Patch.7z"`