### PR TITLE
Migrate to new settings file to avoid compat issues

### DIFF
--- a/src/handlerstorage.cpp
+++ b/src/handlerstorage.cpp
@@ -8,7 +8,7 @@
 static const QRegularExpression invalid_arguments("\"?%[0-9]+\"?");
 
 HandlerStorage::HandlerStorage(const QString& storagePath, QObject* parent)
-    : QObject(parent), m_SettingsPath(storagePath + "/nxmhandler.ini")
+    : QObject(parent), m_SettingsPath(storagePath + "/downloadhandler.ini")
 {
   loadStore();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,6 +103,15 @@ HandlerStorage* registerSchemaExecutable(const QDir& storagePath,
   return storage;
 }
 
+QSettings resolveSettings(QDir baseDir)
+{
+  if (!baseDir.exists("downloadhandler.ini") && baseDir.exists("nxmhandler.ini")) {
+    QFile oldSettings(baseDir.absoluteFilePath("nxmhandler.ini"));
+    oldSettings.copy(baseDir.absoluteFilePath("downloadhandler.ini"));
+  }
+  return QSettings(baseDir.absoluteFilePath("downloadhandler.ini"));
+}
+
 HandlerStorage* registerHandler(HandlerStorage* storage, const QString& schema,
                                 bool forceReg)
 {
@@ -125,21 +134,21 @@ HandlerStorage* registerHandler(HandlerStorage* storage, const QString& schema,
 
   QDir handlerBaseDir = QFileInfo(handlerPath).absoluteDir();
 
-  QSettings settings(baseDir.absoluteFilePath("nxmhandler.ini"), QSettings::IniFormat);
-  bool noRegister = settings.value("noregister", false).toBool();
-  if (globalStorage.exists("nxmhandler.ini") &&
+  QSettings settings = resolveSettings(baseDir);
+  bool noRegister    = settings.value("noregister", false).toBool();
+  if (globalStorage.exists("downloadhandler.ini") &&
       handlerPath.endsWith("nxmhandler.exe", Qt::CaseInsensitive) &&
       QFile::exists(handlerPath)) {
-    // global configuration avaible - use it
+    // global configuration available - use it
     if (storage == nullptr)
       storage = new HandlerStorage(globalStorage.path());
-  } else if (handlerBaseDir.exists("nxmhandler.ini") &&
+  } else if (handlerBaseDir.exists("downloadhandler.ini") &&
              handlerPath.endsWith("nxmhandler.exe", Qt::CaseInsensitive) &&
              QFile::exists(handlerPath)) {
     // a portable installation is registered to handle links, use its
     // configuration
     if (storage == nullptr)
-      storage = new HandlerStorage(globalStorage.path());
+      storage = new HandlerStorage(handlerBaseDir.path());
     if (forceReg && (QString::compare(QDir::toNativeSeparators(
                                           QCoreApplication::applicationFilePath()),
                                       handlerPath, Qt::CaseInsensitive))) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,8 @@ QSettings resolveSettings(QDir baseDir)
     QFile oldSettings(baseDir.absoluteFilePath("nxmhandler.ini"));
     oldSettings.copy(baseDir.absoluteFilePath("downloadhandler.ini"));
   }
-  return QSettings(baseDir.absoluteFilePath("downloadhandler.ini"));
+  return QSettings(baseDir.absoluteFilePath("downloadhandler.ini"),
+                   QSettings::IniFormat);
 }
 
 HandlerStorage* registerHandler(HandlerStorage* storage, const QString& schema,


### PR DESCRIPTION
While the settings did upgrade smoothly, backward compatibility is a bigger issue that I first considered.

Running old nxmhandlers will break the MODL settings and can cause the launch args to transfer to the NXM handler settings.

This breaks the NXM link forwarding between MO2 installs as the args no longer start with the nxm:\\ schema.

Now we copy the old nxmhandler.ini to a new downloadhandler.ini (if it doesn't exist) and use that for new nxmhandler.exe versions.

This effectively segments the settings between new and old handlers, preventing mixups when users have multiple differing MO2 versions.